### PR TITLE
Update API json decoding to use utf8 by default

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -154,7 +154,7 @@ class Default{{.Name}} implements {{.Name}} {
 		if (response.statusCode != 200) {
      		throw twirpException(response);
     	}
-    	var value = json.decode(response.body);
+    	var value = json.decode(utf8.decode(response.bodyBytes));
     	return {{.OutputType}}.fromJson(value);
 	}
     {{end}}


### PR DESCRIPTION
By default, the Dart HTTP decoding will assume that the charset is ISO-8859-1 (latin-1). This causes emojis, certain apostrophe characters, etc to not function correctly. 
See here for extended discussion on why:
https://github.com/dart-lang/http/issues/175

Essentially, this occurs when the content-type header returns without a charset.