### PR TITLE
Add support for API Pool Queue

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -177,11 +177,12 @@ class Default{{.Name}} implements {{.Name}} {
 		var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
     	request.body = json.encode({{.InputArg}}.toJson());
-    	var response = await _apiQueue(() =>_requester.send(request));
-		if (response.statusCode != 200) {
-     		throw twirpException(response);
-    	}
-		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
+    	return _apiQueue(() =>_requester.send(request)).then((response) {
+			if (response.statusCode != 200) {
+				throw twirpException(response);
+		   }
+		   return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
+		});
 	}
 	{{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -174,11 +174,12 @@ class Default{{.Name}} implements {{.Name}} {
     	var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
     	request.body = json.encode({{.InputArg}}.toJson());
-    	var response = await _apiQueue(() =>_requester.send(request));
-		if (response.statusCode != 200) {
-     		throw twirpException(response);
-    	}
-		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
+    	return _apiQueue(() =>_requester.send(request)).then((response) {
+			if (response.statusCode != 200) {
+				throw twirpException(response);
+		   }
+		   return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
+		});
 	}
     {{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -134,14 +134,6 @@ abstract class {{.Name}} {
     {{- end}}
 }
 
-Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
-	return callback();
-}
-
-Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
-	return callback();
-}
-
 class Default{{.Name}} implements {{.Name}} {
 	final String hostname;
     Requester _requester;
@@ -149,6 +141,14 @@ class Default{{.Name}} implements {{.Name}} {
 	Future<T> Function<T>(FutureOr<T> Function() callback) _isolateQueue;
 	Future<T> Function<T>(FutureOr<T> Function() callback) _apiQueue;
 
+	Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
+		return callback();
+	}
+	
+	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
+		return callback();
+	}
+	
     Default{{.Name}}(this.hostname, {Requester requester, isolateQueue, apiQueue}) {
 		if (requester == null) {
       		_requester = new Requester(new Client());

--- a/generator/client.go
+++ b/generator/client.go
@@ -143,14 +143,6 @@ class Default{{.Name}} implements {{.Name}} {
 	final _pathPrefix = "/twirp/{{.Package}}.{{.Name}}/";
 	Future<T> Function<T>(FutureOr<T> Function() callback) _isolateQueue;
 	Future<T> Function<T>(FutureOr<T> Function() callback) _apiQueue;
-
-	Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
-		return callback();
-	}
-	
-	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
-		return callback();
-	}
 	
     Default{{.Name}}(this.hostname, {Requester requester, isolateQueue, apiQueue}) {
 		if (requester == null) {
@@ -169,7 +161,7 @@ class Default{{.Name}} implements {{.Name}} {
 			_apiQueue = apiQueue;
 		}
 	}
-	
+
 	Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
 		return callback();
 	}
@@ -177,7 +169,7 @@ class Default{{.Name}} implements {{.Name}} {
 	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
 		return callback();
 	}
-
+	
 	{{range .Methods}}
 	Future<{{.OutputType}}>{{.Name}}({{.InputType}} {{.InputArg}}) async {
 		var url = "${hostname}${_pathPrefix}{{.Path}}";

--- a/generator/client.go
+++ b/generator/client.go
@@ -134,7 +134,11 @@ abstract class {{.Name}} {
     {{- end}}
 }
 
-Future<T> _noqueue<T>(FutureOr<T> Function() callback) {
+Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
+	return callback();
+}
+
+Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
 	return callback();
 }
 
@@ -142,18 +146,24 @@ class Default{{.Name}} implements {{.Name}} {
 	final String hostname;
     Requester _requester;
 	final _pathPrefix = "/twirp/{{.Package}}.{{.Name}}/";
-	Future<T> Function<T>(FutureOr<T> Function() callback) _queue;
+	Future<T> Function<T>(FutureOr<T> Function() callback) _isolateQueue;
+	Future<T> Function<T>(FutureOr<T> Function() callback) _apiQueue;
 
-    Default{{.Name}}(this.hostname, {Requester requester, queue}) {
+    Default{{.Name}}(this.hostname, {Requester requester, isolateQueue, apiQueue}) {
 		if (requester == null) {
       		_requester = new Requester(new Client());
     	} else {
 			_requester = requester;
 		}
-		if (queue == null) {
-			_queue = _noqueue;
+		if (isolateQueue == null) {
+			_isolateQueue = _noIsolateQueue;
 		} else {
-			_queue = queue;
+			_isolateQueue = isolateQueue;
+		}
+		if (apiQueue == null) {
+			_apiQueue = _noApiQueue;
+		} else {
+			_apiQueue = apiQueue;
 		}
 	}
 
@@ -164,11 +174,11 @@ class Default{{.Name}} implements {{.Name}} {
     	var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
     	request.body = json.encode({{.InputArg}}.toJson());
-    	var response = await _requester.send(request);
+    	var response = await _apiQueue(() =>_requester.send(request));
 		if (response.statusCode != 200) {
      		throw twirpException(response);
     	}
-		return _queue(() => compute({{.Name}}Decode, response.bodyBytes));
+		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
 	}
     {{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -176,12 +176,12 @@ class Default{{.Name}} implements {{.Name}} {
 		var uri = Uri.parse(url);
 		var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
-    	request.body = json.encode({{.InputArg}}.toJson());
-    	var response = await _apiQueue(() =>_requester.send(request));
+		request.body = json.encode({{.InputArg}}.toJson());
+		var response = await _apiQueue(() =>_requester.send(request));
 		if (response.statusCode != 200) {
-     		throw twirpException(response);
-    	}
-		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
+			throw twirpException(response);
+		}
+		return _isolateQueue(() => compute({{$serviceName}}Decode, response.bodyBytes));
 	}
 	{{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -174,12 +174,11 @@ class Default{{.Name}} implements {{.Name}} {
     	var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
     	request.body = json.encode({{.InputArg}}.toJson());
-    	return _apiQueue(() =>_requester.send(request)).then((response) {
-			if (response.statusCode != 200) {
-				throw twirpException(response);
-		   }
-		   return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
-		});
+    	var response = await _apiQueue(() =>_requester.send(request));
+		if (response.statusCode != 200) {
+     		throw twirpException(response);
+    	}
+		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
 	}
     {{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -181,7 +181,7 @@ class Default{{.Name}} implements {{.Name}} {
 		if (response.statusCode != 200) {
 			throw twirpException(response);
 		}
-		return _isolateQueue(() => compute({{$serviceName}}Decode, response.bodyBytes));
+		return _isolateQueue(() => compute({{.Name}}{{$serviceName}}Decode, response.bodyBytes));
 	}
 	{{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -185,12 +185,11 @@ class Default{{.Name}} implements {{.Name}} {
 		var request = new Request('POST', uri);
 		request.headers['Content-Type'] = 'application/json';
     	request.body = json.encode({{.InputArg}}.toJson());
-    	return _apiQueue(() =>_requester.send(request)).then((response) {
-			if (response.statusCode != 200) {
-				throw twirpException(response);
-		   }
-		   return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
-		});
+    	var response = await _apiQueue(() =>_requester.send(request));
+		if (response.statusCode != 200) {
+     		throw twirpException(response);
+    	}
+		return _isolateQueue(() => compute({{.Name}}Decode, response.bodyBytes));
 	}
 	{{end}}
 

--- a/generator/client.go
+++ b/generator/client.go
@@ -144,6 +144,14 @@ class Default{{.Name}} implements {{.Name}} {
 	Future<T> Function<T>(FutureOr<T> Function() callback) _isolateQueue;
 	Future<T> Function<T>(FutureOr<T> Function() callback) _apiQueue;
 
+	Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
+		return callback();
+	}
+	
+	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
+		return callback();
+	}
+	
     Default{{.Name}}(this.hostname, {Requester requester, isolateQueue, apiQueue}) {
 		if (requester == null) {
 			_requester = new Requester(new Client());

--- a/generator/client.go
+++ b/generator/client.go
@@ -143,17 +143,6 @@ class Default{{.Name}} implements {{.Name}} {
 	final _pathPrefix = "/twirp/{{.Package}}.{{.Name}}/";
 	Future<T> Function<T>(FutureOr<T> Function() callback) _isolateQueue;
 	Future<T> Function<T>(FutureOr<T> Function() callback) _apiQueue;
-<<<<<<< HEAD
-=======
-
-	Future<T> _noIsolateQueue<T>(FutureOr<T> Function() callback) {
-		return callback();
-	}
-	
-	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
-		return callback();
-	}
->>>>>>> 3621a7c2cfe2c8135c944e0542c459aabe68bac7
 	
     Default{{.Name}}(this.hostname, {Requester requester, isolateQueue, apiQueue}) {
 		if (requester == null) {
@@ -180,7 +169,7 @@ class Default{{.Name}} implements {{.Name}} {
 	Future<T> _noApiQueue<T>(FutureOr<T> Function() callback) {
 		return callback();
 	}
-	
+
 	{{range .Methods}}
 	Future<{{.OutputType}}>{{.Name}}({{.InputType}} {{.InputArg}}) async {
 		var url = "${hostname}${_pathPrefix}{{.Path}}";


### PR DESCRIPTION
Adds a separate queue for the API calls themselves, this allows us to limit the amount of in flight API connections to prevent saturating services.